### PR TITLE
Fixed error with battery notification and added dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ An almost desktop environment made with [AwesomeWM](https://awesomewm.org/) foll
 
 ```
 sudo add-apt-repository ppa:regolith-linux/unstable -y
-sudo apt install awesome fonts-roboto rofi picom i3lock xclip qt5-style-plugins materia-gtk-theme lxappearance xbacklight kde-spectacle nautilus xfce4-power-manager pnmixer network-manager-applet gnome-polkit -y
+sudo apt install awesome fonts-roboto rofi picom i3lock xclip qt5-style-plugins materia-gtk-theme lxappearance xbacklight kde-spectacle nautilus xfce4-power-manager pnmixer network-manager-applet gnome-polkit alsa-utils acpi -y
 wget -qO- https://git.io/papirus-icon-theme-install | sh
 ```
 
@@ -29,7 +29,7 @@ wget -qO- https://git.io/papirus-icon-theme-install | sh
 #### Arch-Based
 
 ```
-yay -S awesome rofi picom i3lock-fancy xclip ttf-roboto gnome-polkit materia-gtk-theme lxappearance flameshot pnmixer network-manager-applet xfce4-power-manager -y
+yay -S awesome rofi picom i3lock-fancy xclip ttf-roboto gnome-polkit materia-gtk-theme lxappearance flameshot pnmixer network-manager-applet xfce4-power-manager alsa-utils acpi -y
 wget -qO- https://git.io/papirus-icon-theme-install | sh
 ```
 
@@ -46,10 +46,12 @@ wget -qO- https://git.io/papirus-icon-theme-install | sh
 - [Papirus Dark](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme) as icon theme Universal Install: wget -qO- https://git.io/papirus-icon-theme-install | sh
 - [lxappearance](https://sourceforge.net/projects/lxde/files/LXAppearance/) to set up the gtk and icon theme
 - (Laptop) [xbacklight](https://www.x.org/archive/X11R7.5/doc/man/man1/xbacklight.1.html) for adjusting brightness on laptops (disabled by default)
+- (Laptop) [acpi](https://sourceforge.net/projects/acpiclient/files/acpiclient/) for the battery widget
 - [flameshot](https://flameshot.js.org/#/) my personal screenshot utility of choice, can be replaced by whichever you want, just remember to edit the apps.lua file
 - [pnmixer](https://github.com/nicklan/pnmixer) Audio Tray icon that is in debian repositories and is easily installed on arch through AUR.
 - [network-manager-applet](https://gitlab.gnome.org/GNOME/network-manager-applet) nm-applet is a Network Manager Tray display from GNOME.
 - [xfce4-power-manager](https://docs.xfce.org/xfce/xfce4-power-manager/start) XFCE4's power manager is excellent and a great way of dealing with sleep, monitor timeout, and other power management features.
+- [alsa-utils](https://www.alsa-project.org/wiki/Download#alsa-utils) for the sound control
 
 ### 2) Clone the configuration
 

--- a/widget/battery/init.lua
+++ b/widget/battery/init.lua
@@ -117,7 +117,7 @@ watch(
     if (charge >= 0 and charge < 15) then
       if status ~= 'Charging' and os.difftime(os.time(), last_battery_check) > 300 then
         -- if 5 minutes have elapsed since the last warning
-        last_battery_check = _G.time()
+        last_battery_check = os.time()
 
         show_battery_warning()
       end


### PR DESCRIPTION
### Battery notifications
When battery percentage goes under 15%, awesome should send a warning notification every 5 minutes. However, there was an error every time it reached this percentage. Turned out that the error was coming from the use of `_G.time()` (which does not exist) instead of `os.time()` in the battery widget code.

### Dependencies
This same battery widget is using the **acpi** package for getting the battery percentage. However, this package isn't installed by default on Arch.
The sound control slider and the keybindings for the sound (XF86Audio... keys) use the **alsa-utils** package, and especially its `amixer` command to handle the volume of the sound. However, this package isn't installed by default on Arch.